### PR TITLE
To ensure BufferTime when AkamaiAdvancedPlugin is used

### DIFF
--- a/src/ru/kutu/grindplayer/config/JavaScriptBridge.as
+++ b/src/ru/kutu/grindplayer/config/JavaScriptBridge.as
@@ -1,15 +1,30 @@
 package ru.kutu.grindplayer.config {
 	
 	import flash.external.ExternalInterface;
+	import flash.net.NetStream;
 	
 	import org.osmf.events.MediaPlayerCapabilityChangeEvent;
 	import org.osmf.events.MetadataEvent;
+	
+	import org.osmf.events.MediaPlayerStateChangeEvent;
+	import org.osmf.events.TimeEvent;
+	import org.osmf.events.LoadEvent;
+	import org.osmf.media.MediaPlayerState;
+	import org.osmf.traits.MediaTraitType;
+	import org.osmf.traits.LoadState;
+	import org.osmf.net.NetStreamLoadTrait;
 	
 	import ru.kutu.grind.config.JavaScriptBridgeBase;
 	import ru.kutu.grind.events.MediaElementChangeEvent;
 	import ru.kutu.osmf.subtitles.SubtitlesEvent;
 	
+	import robotlegs.bender.framework.api.ILogger;
+	
 	public class JavaScriptBridge extends JavaScriptBridgeBase {
+		
+		[Inject] public var logger:ILogger;
+		
+		private var netStream:NetStream = null;
 		
 		public function JavaScriptBridge() {
 			declaredByWhiteList.push("ru.kutu.grindplayer.media::GrindMediaPlayer");
@@ -36,6 +51,15 @@ package ru.kutu.grindplayer.config {
 			eventMaps[SubtitlesEvent.HAS_SUBTITLES_CHANGE]			= function(event:MediaPlayerCapabilityChangeEvent):Array{return [event.enabled];};
 		}
 		
+		[PostConstruct]
+		override public function init():void {
+			super.init();
+			
+			player.addEventListener(MediaPlayerStateChangeEvent.MEDIA_PLAYER_STATE_CHANGE, onPlayerStateChangeForBufferTimeAdjustment);
+			player.addEventListener(LoadEvent.LOAD_STATE_CHANGE, onLoadStateChangeToGetNetStream);
+			player.addEventListener(TimeEvent.CURRENT_TIME_CHANGE, onCurrentTimeChangeForBufferTimeAdjustment);
+		}
+		
 		private function onMediaMetadataChange(event:MetadataEvent):void {
 			if (event.key == "Advertisement") {
 				var ids:Array = [];
@@ -48,6 +72,41 @@ package ru.kutu.grindplayer.config {
 			}
 		}
 		
+		private function onPlayerStateChangeForBufferTimeAdjustment(e:MediaPlayerStateChangeEvent):void
+		{
+			if (e.state == MediaPlayerState.PAUSED)
+			{
+				if ( netStream != null ) {
+					if (netStream.bufferTime != player.bufferTime) {
+						CONFIG::LOGGING {
+							logger.info("NetStream BufferTime: " + netStream.bufferTime);
+						}
+						
+						netStream.bufferTime = player.bufferTime;
+					}
+					CONFIG::LOGGING {
+						logger.info("Player State: " + player.state + "," + player.bufferTime + "," + netStream.bufferTime);
+					}
+				}
+			}
+		}
+		
+		private function onLoadStateChangeToGetNetStream(e:LoadEvent):void {
+			if (e.loadState == LoadState.READY) {
+				var nsLoadTrait:NetStreamLoadTrait = player.media.getTrait(MediaTraitType.LOAD) as NetStreamLoadTrait;
+				netStream = nsLoadTrait.netStream;
+			}
+		}
+		
+		private function onCurrentTimeChangeForBufferTimeAdjustment(event:TimeEvent):void {
+			if ( netStream != null ) {
+				if (player.state != MediaPlayerState.BUFFERING) {
+					netStream.bufferTime = player.bufferTime;
+				} else {
+					netStream.bufferTime = 2;
+				}
+			}
+		}
 	}
 	
 }


### PR DESCRIPTION
I came to know why buffer size cannot be increased when using AkamaiAdvancedPlugin. It is because the buffer time is depend on a “NetStream” instance instead of “MediaPlayer”. So if I set up a value of the buffer time on a “MediaPlayer” instance by javascript bridge, it cannot be applied. Instead of it Akamai plugin may has a default value or a base value depend on an environment that include a stream type, network and server condition. I don’t know exactly. I try to control a value of the buffer time in “NetStream” instance on actionscript. In this case, when a stream is paused, it works find but it is on playing, then the value is changed. So I try to change the value when current time value is changed. The result is successful. Please consider this modification.

Thanks.
